### PR TITLE
Get unread messages count

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -1167,6 +1167,18 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Gets the count of Unread messages in the inbox.
+     */
+    @ReactMethod
+    public void getUnreadMessagesCount(Promise promise) {
+        if (!Utils.ensureAirshipReady(promise)) {
+            return;
+        }
+
+        promise.resolve(MessageCenter.shared().getInbox().getUnreadCount());
+    }
+
+    /**
      * Sets the default behavior when the message center is launched from a push notification. If set to false the message center must be manually launched.
      *
      * @param enabled {@code true} to automatically launch the default message center, {@code false} to disable.

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -929,6 +929,16 @@ RCT_EXPORT_METHOD(clearNotification:(NSString *)identifier) {
     }
 }
 
+RCT_REMAP_METHOD(getUnreadMessagesCount,
+                 getUnreadMessagesCount_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    if (![self ensureAirshipReady:reject]) {
+        return;
+    }
+    
+    resolve(@([UAMessageCenter shared].messageList.unreadCount));
+}
+
 RCT_REMAP_METHOD(getActiveNotifications,
                  getNotifications_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -831,6 +831,13 @@ export class UrbanAirship {
   }
 
   /**
+   * Gets the count of Unread messages in the inbox.
+   */
+  static getUnreadMessageCount(): number {
+    return UrbanAirshipModule.getUnreadMessagesCount();
+  }
+
+  /**
    * Checks if app notifications are enabled or not. Its possible to have `userNotificationsEnabled`
    * but app notifications being disabled if the user opted out of notifications.
    *


### PR DESCRIPTION
Adds a `getUnreadMessagesCount` function to expose the number of unread messages within the user Inbox